### PR TITLE
add missing class_name to GeometricShape.gd

### DIFF
--- a/addons/2d_shapes/shapes/GeometricShape.gd
+++ b/addons/2d_shapes/shapes/GeometricShape.gd
@@ -1,4 +1,4 @@
-extends Node2D
+class_name GeometricShape extends Node2D
 
 
 var polygon : PackedVector2Array


### PR DESCRIPTION
Declare the class `GeometricShape` in `GeometricShape.gd`