### PR TITLE
Make GeometricShape node abstract

### DIFF
--- a/addons/2d_shapes/shapes/GeometricShape.gd
+++ b/addons/2d_shapes/shapes/GeometricShape.gd
@@ -1,6 +1,6 @@
 @tool
 @icon("res://addons/2d_shapes/icon.svg")
-class_name GeometricShape extends Node2D
+@abstract class_name GeometricShape extends Node2D
 
 
 var polygon: PackedVector2Array


### PR DESCRIPTION
When adding a GeometricShape to the scene the addon gives the error "GeometricShape should not be used directly."

The Godot 4 @abstract annotation prevents the node from being added in the first place.

Addon still works fine in Godot 4.6.1